### PR TITLE
feat: Update entity handling for runtime verb parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ rmlmapper-5.0.0-r362-all.jar
 tmp
 comake-skl-js-engine-*.tgz
 test/deploy/package-lock.json
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@comake/skl-js-engine",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@comake/skl-js-engine",
-			"version": "0.25.0",
+			"version": "0.25.1",
 			"license": "BSD-4-Clause",
 			"dependencies": {
 				"@comake/openapi-operation-executor": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@comake/skl-js-engine",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"description": "Standard Knowledge Language Javascript Engine",
 	"keywords": [
 		"skl",

--- a/src/util/Vocabularies.ts
+++ b/src/util/Vocabularies.ts
@@ -97,6 +97,14 @@ export const SKL = createNamespace(SKL_NAMESPACE, [
   'headers',
 ]);
 
+export const SKLSO_DATA_NAMESPACE = 'https://skl.so/d/';
+
+export const SKLSO_PROPERTY_NAMESPACE = 'https://skl.so/p/';
+export const SKLSO_PROPERTY = createNamespace(SKLSO_PROPERTY_NAMESPACE, [
+  'type',
+  'identifier',
+]);
+
 export const SKL_ENGINE_NAMESPACE = 'https://standardknowledge.com/ontologies/skl-engine/';
 export const SKL_ENGINE = createNamespace(SKL_ENGINE_NAMESPACE, [
   'update',


### PR DESCRIPTION
## Summary of Changes
Update runtime verb parameters in SKLEngine to handle entity IDs and types from the SKLSO data namespace

## Technical Details
- Add SKLSO_DATA_NAMESPACE and SKLSO_PROPERTY_NAMESPACE constants
- Add replaceTypeAndId function to replace entity `@type` and `@id` with sklso:type and sklso:identifier properties
- Update updateEntityFromVerbArgs, saveEntityOrEntitiesFromVerbArgs, and destroyEntityOrEntitiesFromVerbArgs to call replaceTypeAndId before saving/updating/deleting entities
- Add .env to .gitignore

## Commit History
* Update runtime verb parameters